### PR TITLE
Ask user if they want to show all commands being executed

### DIFF
--- a/unix-setup/setup.sh
+++ b/unix-setup/setup.sh
@@ -1,5 +1,44 @@
 #!/usr/bin/env bash
 
+# from https://web.archive.org/web/20210922125055/https://gist.github.com/davejamesmiller/1965569#file-ask-sh
+function ask() {
+    local prompt default reply
+
+    if [[ ${2:-} = 'Y' ]]; then
+        prompt='Y/n'
+        default='Y'
+    elif [[ ${2:-} = 'N' ]]; then
+        prompt='y/N'
+        default='N'
+    else
+        prompt='y/n'
+        default=''
+    fi
+
+    while true; do
+
+        # Ask the question (not using "read -p" as it uses stderr not stdout)
+        echo -n "$1 [$prompt] "
+
+        # Read the answer (use /dev/tty in case stdin is redirected from somewhere else)
+        read -r reply </dev/tty
+
+        # Default?
+        if [[ -z $reply ]]; then
+            reply=$default
+        fi
+
+        # Check if the reply is valid
+        case "$reply" in
+            Y*|y*) return 0 ;;
+            N*|n*) return 1 ;;
+        esac
+
+	echo 'please answer with "yes" or "no"'
+
+    done
+}
+
 function install_snap() {
 
 cat << EOF
@@ -37,7 +76,9 @@ to let your know all the things that I am doing
 
 EOF
 
-sleep 10
+if ask "Would you like me to show you exactly which commands I run?"; then
+	set -x
+fi
 
 OS=$(uname -s)
 

--- a/unix-setup/setup.sh
+++ b/unix-setup/setup.sh
@@ -76,7 +76,7 @@ to let your know all the things that I am doing
 
 EOF
 
-if ask "Would you like me to show you exactly which commands I run?"; then
+if ask "Would you like me to show you exactly which commands I run?" Y; then
 	set -x
 fi
 


### PR DESCRIPTION
This pull request implements the following:

- `ask` function from [this GitHub gist](https://web.archive.org/web/20210922125055/https://gist.github.com/davejamesmiller/1965569#file-ask-sh)
- Prompts user if they want to enable `set -x` within the script, printing all commands that are executed. "Yes" is the default answer but you can change this if it doesn't fit Nucamp's core values or whatever.
- Removes the `sleep 10` line after the introductory statement — the question will pause the script's flow instead.

I've included the entirety of the `ask` function in case this script ever gets refactored. It's only a couple hundred bytes longer than it has to be (if it's only used once) but with a script this short that shouldn't be of any consequence. Please request any changes you'd like, I'd be happy to hear them!

###### *not LLM output — I'm just like this.*
<!-- [disclaimer](https://xkcd.com/3126) -->
